### PR TITLE
Make the stomp backend actually pass through the username and password

### DIFF
--- a/carrot/backends/pystomp.py
+++ b/carrot/backends/pystomp.py
@@ -91,7 +91,7 @@ class Backend(BaseBackend):
         if not conninfo.port:
             conninfo.port = self.default_port
         stomp = self.Stomp(conninfo.hostname, conninfo.port)
-        stomp.connect()
+        stomp.connect(username=conninfo.userid, password=conninfo.password)
         stomp.drain_events = self.drain_events
         return stomp
 


### PR DESCRIPTION
This commit makes the stomp backend actually pass through the username and password
