### PR TITLE
docs: Fix a few typos

### DIFF
--- a/carrot/backends/librabbitmq.py
+++ b/carrot/backends/librabbitmq.py
@@ -18,7 +18,7 @@ DEFAULT_PORT = 5672
 class Message(BaseMessage):
     """A message received by the broker.
 
-    Usually you don't insantiate message objects yourself, but receive
+    Usually you don't instantiate message objects yourself, but receive
     them using a :class:`carrot.messaging.Consumer`.
 
     :param backend: see :attr:`backend`.

--- a/carrot/backends/pyamqplib.py
+++ b/carrot/backends/pyamqplib.py
@@ -114,7 +114,7 @@ class QueueAlreadyExistsWarning(UserWarning):
 class Message(BaseMessage):
     """A message received by the broker.
 
-    Usually you don't insantiate message objects yourself, but receive
+    Usually you don't instantiate message objects yourself, but receive
     them using a :class:`carrot.messaging.Consumer`.
 
     :param backend: see :attr:`backend`.

--- a/carrot/backends/pystomp.py
+++ b/carrot/backends/pystomp.py
@@ -13,7 +13,7 @@ DEFAULT_PORT = 61613
 class Message(BaseMessage):
     """A message received by the STOMP broker.
 
-    Usually you don't insantiate message objects yourself, but receive
+    Usually you don't instantiate message objects yourself, but receive
     them using a :class:`carrot.messaging.Consumer`.
 
     :param backend: see :attr:`backend`.

--- a/carrot/messaging.py
+++ b/carrot/messaging.py
@@ -494,7 +494,7 @@ class Consumer(object):
         content data.
 
         This is a simple flow-control mechanism that a
-        peer can use to avoid oveflowing its queues or otherwise
+        peer can use to avoid overflowing its queues or otherwise
         finding itself receiving more messages than it can process.
         Note that this method is not intended for window control.  The
         peer that receives a request to stop sending content should

--- a/carrot/utils.py
+++ b/carrot/utils.py
@@ -7,7 +7,7 @@ except ImportError:
 
 def gen_unique_id():
     """Generate a unique id, having - hopefully - a very small chance of
-    collission.
+    collision.
 
     For now this is provided by :func:`uuid.uuid4`.
     """


### PR DESCRIPTION
There are small typos in:
- carrot/backends/librabbitmq.py
- carrot/backends/pyamqplib.py
- carrot/backends/pystomp.py
- carrot/messaging.py
- carrot/utils.py

Fixes:
- Should read `instantiate` rather than `insantiate`.
- Should read `overflowing` rather than `oveflowing`.
- Should read `collision` rather than `collission`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md